### PR TITLE
feat(integration): add timeout to Claude CLI calls

### DIFF
--- a/.speckit/features/integration-testing/checklist.md
+++ b/.speckit/features/integration-testing/checklist.md
@@ -86,7 +86,7 @@
 |--------|-------------|----------|------------|
 | GAP-001 | Soft assertions in integration tests | High | ✅ RESOLVED: Added `--strict` mode (#59) |
 | GAP-002 | No CI/CD workflow for IQ/OQ/PQ | High | Create GitHub Actions |
-| GAP-003 | No timeout on Claude CLI calls | Medium | Add 60s timeout |
+| GAP-003 | No timeout on Claude CLI calls | Medium | ✅ RESOLVED: Added 60s timeout (#60) |
 | GAP-004 | No memory usage tests | Medium | Add pq_memory.rs |
 | GAP-005 | No stress/endurance tests | Medium | Add pq_stress.rs |
 | GAP-006 | Limited cross-platform IQ | Medium | Add CI runners |

--- a/.speckit/features/integration-testing/tasks.md
+++ b/.speckit/features/integration-testing/tasks.md
@@ -371,15 +371,18 @@
 - [x] `task integration-test-strict` Taskfile task
 
 ### Task 8.2: Add Claude CLI Timeout
-**Status:** [ ] Pending  
+**Status:** [x] Complete  
 **Complexity:** Low  
-**Gap:** GAP-003 (No timeout)  
-**Files:** `test/integration/lib/test-helpers.sh`
+**Gap:** GAP-003 (No timeout) - RESOLVED  
+**Files:** `test/integration/lib/test-helpers.sh`, `test/integration/run-all.sh`
+**PR:** #65 (feature/claude-cli-timeout)
 
 **Acceptance Criteria:**
-- [ ] 60-second default timeout
-- [ ] Configurable via environment
-- [ ] Clear timeout error message
+- [x] 60-second default timeout
+- [x] Configurable via environment (CLAUDE_TIMEOUT)
+- [x] Configurable via command-line (--timeout)
+- [x] Clear timeout error message
+- [x] Cross-platform support (timeout/gtimeout)
 
 ### Task 8.3: Update Release Workflow
 **Status:** [x] Complete  

--- a/test/integration/run-all.sh
+++ b/test/integration/run-all.sh
@@ -5,8 +5,10 @@
 #   ./run-all.sh              # Run all tests (soft assertions)
 #   ./run-all.sh --strict     # Run with strict mode (fail-fast)
 #   ./run-all.sh --quick      # Run only quick tests (skip slow ones)
+#   ./run-all.sh --timeout 120  # Set custom timeout (seconds)
 #   DEBUG=1 ./run-all.sh      # Run with debug output
 #   STRICT_MODE=1 ./run-all.sh  # Alternative strict mode via env var
+#   CLAUDE_TIMEOUT=120 ./run-all.sh  # Alternative timeout via env var
 
 set -euo pipefail
 
@@ -27,13 +29,17 @@ while [[ $# -gt 0 ]]; do
             export STRICT_MODE=1
             shift
             ;;
+        --timeout)
+            export CLAUDE_TIMEOUT="$2"
+            shift 2
+            ;;
         --test)
             SPECIFIC_TEST="$2"
             shift 2
             ;;
         *)
             echo "Unknown option - $1"
-            echo "Usage - ./run-all.sh [--quick] [--strict] [--test <test-name>]"
+            echo "Usage - ./run-all.sh [--quick] [--strict] [--timeout <seconds>] [--test <test-name>]"
             exit 1
             ;;
     esac
@@ -49,6 +55,7 @@ if [ "${STRICT_MODE:-0}" = "1" ]; then
 else
     echo -e "|       MODE: Normal (soft assertions)                       |"
 fi
+echo -e "|       TIMEOUT: ${CLAUDE_TIMEOUT}s per Claude CLI call                        |"
 echo -e "${BLUE}+============================================================+${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary
Adds configurable timeout to Claude CLI invocations in integration tests, addressing GAP-003.

## Problem
The current `run_claude` function has no timeout. If Claude prompts for permission or hangs for any reason, the test hangs indefinitely, blocking CI pipelines.

## Solution
Wrap Claude CLI calls with the `timeout` command (or `gtimeout` on macOS) with a configurable timeout.

## Changes
- **test-helpers.sh**: Add `CLAUDE_TIMEOUT` env var (default: 60s)
- **test-helpers.sh**: Add `get_timeout_cmd()` for cross-platform support
- **test-helpers.sh**: Update `run_claude()` to use timeout wrapper
- **run-all.sh**: Add `--timeout` command-line flag
- **run-all.sh**: Display timeout in test banner
- **checklist.md**: Mark GAP-003 as resolved
- **tasks.md**: Mark Task 8.2 as complete

## Usage
```bash
# Via command-line flag
./test/integration/run-all.sh --timeout 120

# Via environment variable
CLAUDE_TIMEOUT=120 ./test/integration/run-all.sh

# Default (60 seconds)
./test/integration/run-all.sh
```

## Exit Codes
- `0` - Success
- `124` - Timeout (Claude did not respond in time)
- Other - Claude CLI error

## Cross-Platform Support
- Linux: Uses `timeout` command
- macOS: Uses `timeout` (from coreutils) or `gtimeout`
- Falls back gracefully with warning if neither available

## Testing
- [x] Shell script syntax validation (`bash -n`)
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes

## Closes
Closes #60