### PR TITLE
fix(ci): update macOS Intel runner to macos-15-intel

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -68,7 +68,9 @@ jobs:
   iq-macos-intel:
     name: IQ - macOS Intel
     if: ${{ github.event.inputs.skip_iq != 'true' }}
-    runs-on: macos-13
+    # Note: macos-13 was retired Jan 2026 (see actions/runner-images#13046)
+    # Using macos-15-intel - last supported x86_64 image (until Aug 2027)
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Fixes the Full Validation workflow failing due to retired macOS 13 runners.

## Problem

- GitHub retired `macos-13` runners in January 2026
- The IQ - macOS Intel job was being auto-cancelled

## Solution

- Updated `runs-on: macos-13` to `runs-on: macos-15-intel`
- This is the last supported x86_64 image (until August 2027)

## Reference

- [actions/runner-images#13046](https://github.com/actions/runner-images/issues/13046)