### PR TITLE
chore: prepare v1.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Release workflow for CCH (Claude Code Hooks)
+# Release workflow for RuleZ (AI Policy Engine)
 #
 # This workflow creates cross-platform releases when a tag is pushed.
 # It builds binaries for:
@@ -31,26 +31,26 @@ jobs:
           # Linux
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: cch
-            asset_name: cch-linux-x86_64
+            artifact_name: rulez
+            asset_name: rulez-linux-x86_64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            artifact_name: cch
-            asset_name: cch-linux-aarch64
+            artifact_name: rulez
+            asset_name: rulez-linux-aarch64
           # macOS
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: cch
-            asset_name: cch-macos-x86_64
+            artifact_name: rulez
+            asset_name: rulez-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: cch
-            asset_name: cch-macos-aarch64
+            artifact_name: rulez
+            asset_name: rulez-macos-aarch64
           # Windows
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: cch.exe
-            asset_name: cch-windows-x86_64.exe
+            artifact_name: rulez.exe
+            asset_name: rulez-windows-x86_64.exe
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,60 @@
 # Changelog
 
-All notable changes to Claude Context Hooks (CCH) will be documented in this file.
+All notable changes to RuleZ (AI Policy Engine) will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.0] - 2026-02-10
+
+### Renamed
+
+- **Project renamed from CCH (Claude Context Hooks) to RuleZ** — binary, configs, logs, and all references updated
+- Binary: `cch` -> `rulez`
+- Log file: `cch.log` -> `rulez.log`
+- Release assets: `cch-*` -> `rulez-*`
+
+### Added
+
+#### v1.2 — Inline Content & Conditional Rules
+- **`inject_inline`** — Embed context directly in YAML rules without external files
+- **`inject_command`** — Generate dynamic context via shell commands at evaluation time
+- **`enabled_when`** — Conditional rule activation with evalexpr expressions (e.g., `event_type == "PreToolUse"`)
+
+#### v1.3 — Advanced Matching & Validation
+- **`prompt_match`** — Regex intent routing against prompt text with case-insensitive, anchored, AND/OR logic
+- **`require_fields` / `field_types`** — Fail-closed field existence and type validation with dot-notation paths
+- **`validate_expr`** — Inline evalexpr expressions with `get_field()` / `has_field()` custom functions
+- **`inline_script`** — Shell scripts embedded in YAML with configurable timeout protection
+
+#### v1.4 — Stability & Polish
+- **JSON Schema validation** — Fail-open schema validation for hook event payloads (<0.1ms overhead via LazyLock pre-compiled validators)
+- **Debug CLI UserPromptSubmit support** — Debug command now handles prompt-submit events
+- **LRU regex cache** (100 entries) — Replaces unbounded HashMap to prevent memory growth
+- **Cross-platform E2E tests** — Path canonicalization for macOS symlinks, CI matrix (ubuntu, macOS, Windows)
+- **Tauri CI build pipeline** — E2E gate before desktop builds, multi-platform Tauri packaging
+
+#### RuleZ UI (Desktop App)
+- Tauri 2.0 desktop app scaffold with React 18, TypeScript 5.7+, Tailwind CSS 4
+- 18 React components, 3 Zustand stores, Monaco YAML editor with schema validation
+- Dual-mode architecture (Tauri desktop + web browser fallback)
+- Playwright E2E tests with Page Object Model (56 tests)
+- `task run-app` command for launching the desktop app
+
+### Fixed
+
+- **Broken pipe in inline scripts** — `Stdio::null()` for stdout/stderr when only checking exit code (Linux CI fix)
+- **Zombie process reaping** — Timeout path now calls `child.kill()` + `child.wait()`
+- **Stale binary artifacts** — Cleaned up old `cch` binaries after rename
+- **E2E test strict mode** — Added `data-testid` attributes for Playwright strict selector compliance
+- **Merge conflict resolution** — Fixed 12 files with leftover conflict markers from concurrent PRs
+
+### Changed
+
+- 634 tests passing (up from 64 in v1.0.0)
+- <3ms rule processing latency maintained across all new features
+- Monorepo structure: `rulez/` (core), `mastering-hooks/` (skill), `rulez-ui/` (desktop app)
+- Release workflow updated: asset names now use `rulez-*` prefix
 
 ## [1.1.0] - 2026-01-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["rulez-ui/src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0"
+version = "1.5.0"
 authors = ["Rick Hightower <rick@spillwave.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
## Summary

Release v1.5.0 covering milestones v1.2, v1.3, v1.4, and the CCH -> RuleZ rename.

### Changes in this PR
- Bump workspace version from 1.1.0 to 1.5.0
- Update release workflow: `cch` -> `rulez` binary and asset names
- Comprehensive CHANGELOG entry

### What's in v1.5.0

**v1.2 — Inline Content & Conditional Rules**
- `inject_inline`, `inject_command`, `enabled_when`

**v1.3 — Advanced Matching & Validation**
- `prompt_match` (regex intent routing), `require_fields`/`field_types`, `validate_expr`, `inline_script`

**v1.4 — Stability & Polish**
- JSON Schema validation (<0.1ms), Debug CLI UserPromptSubmit, LRU regex cache
- Cross-platform E2E tests, Tauri CI build pipeline

**RuleZ UI** — Tauri 2.0 desktop app scaffold (18 components, 56 E2E tests)

**Rename** — CCH -> RuleZ (binary, logs, configs, release assets)

**Fixes** — Broken pipe on Linux, zombie process reaping, stale binaries, E2E strict mode

### Stats
- 634 tests passing
- <3ms rule processing latency
- 5 cross-platform release targets

## Test plan

- [ ] CI passes (fmt + clippy + tests)
- [ ] Release workflow has correct `rulez` binary references
- [ ] Version reads as 1.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)