### PR TITLE
fix(rulez-ui): add data-testid attributes to Sidebar for E2E tests

### DIFF
--- a/rulez-ui/src/components/layout/Sidebar.tsx
+++ b/rulez-ui/src/components/layout/Sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar() {
   };
 
   return (
-    <aside className="w-56 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-surface dark:bg-surface-dark overflow-y-auto">
+    <aside data-testid="sidebar" className="w-56 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-surface dark:bg-surface-dark overflow-y-auto">
       <div className="p-3">
         <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
           Files
@@ -113,6 +113,7 @@ export function Sidebar() {
                 exists={globalConfig.exists}
                 isActive={activeFile === globalConfig.path}
                 onClick={() => handleFileClick(globalConfig.path)}
+                scope="global"
               />
               {globalConfig.exists && (
                 <ExportButton
@@ -153,6 +154,7 @@ export function Sidebar() {
                 exists={projectConfig.exists}
                 isActive={activeFile === projectConfig.path}
                 onClick={() => handleFileClick(projectConfig.path)}
+                scope="project"
               />
               {projectConfig.exists && (
                 <ExportButton
@@ -290,15 +292,17 @@ interface FileItemProps {
   exists: boolean;
   isActive: boolean;
   onClick: () => void;
+  scope: "global" | "project";
 }
 
-function FileItem({ path, exists, isActive, onClick }: FileItemProps) {
+function FileItem({ path, exists, isActive, onClick, scope }: FileItemProps) {
   const fileName = path.split("/").pop() || path;
 
   return (
     <button
       type="button"
       onClick={onClick}
+      data-testid={`sidebar-${scope}-file-${fileName}`}
       className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm text-left transition-colors ${
         isActive
           ? "bg-accent/10 text-accent dark:text-accent-dark"


### PR DESCRIPTION
## Summary
- Add `data-testid` attributes to Sidebar `FileItem` component to fix 8 Playwright E2E test failures
- Tests in `editor.spec.ts` expect `data-testid="sidebar-global-file-hooks.yaml"` but the component was missing these attributes
- Also adds `data-testid="sidebar"` to the container element (expected by `sidebar.page.ts` page object)

## What Changed
- `FileItem` now accepts a `scope` prop (`"global"` | `"project"`)
- Generates `data-testid={sidebar-${scope}-file-${fileName}}` on each file button
- Minimal 6-line change, no behavioral changes

## CI Impact
Fixes these failing checks on PR #91:
- E2E Tests (Web Mode) - 8 failures in `editor.spec.ts`
- Playwright E2E Tests - same 8 failures