### PR TITLE
docs: add manual testing runbooks and fix integration test scripts

### DIFF
--- a/runbooks/01-claude-code.md
+++ b/runbooks/01-claude-code.md
@@ -1,0 +1,456 @@
+# Runbook 01: Claude Code Manual Testing
+
+Manual testing of RuleZ with Claude Code CLI.
+
+## Prerequisites
+
+- [ ] Claude Code CLI installed (`claude --version`)
+- [ ] RuleZ binary built (`cargo build --release` from repo root)
+- [ ] Know your RuleZ binary path (e.g., `/path/to/repo/target/release/rulez`)
+
+Set a variable for convenience:
+
+```bash
+export RULEZ_BIN="/path/to/agent_rulez/target/release/rulez"
+```
+
+---
+
+## Use Case 1: Block Force Push
+
+**Goal**: Verify that RuleZ blocks `git push --force` when Claude tries to run it.
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-test-block/.claude
+cd /tmp/rulez-test-block
+git init
+```
+
+### Step 2: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: block-force-push
+    description: "Prevents destructive force push operations"
+    matchers:
+      tools: ["Bash"]
+      command_match: "git push.*--force|git push.*-f"
+    actions:
+      block: true
+
+  - name: block-hard-reset
+    description: "Prevents destructive hard reset operations"
+    matchers:
+      tools: ["Bash"]
+      command_match: "git reset --hard"
+    actions:
+      block: true
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+  fail_open: false
+EOF
+```
+
+### Step 3: Install RuleZ
+
+```bash
+$RULEZ_BIN install
+```
+
+Expected output:
+```
+Installing RuleZ hook...
+  Binary: /path/to/rulez
+  Settings: .claude/settings.json
+  Scope: project
+
+✓ RuleZ installed successfully!
+```
+
+### Step 4: Dry-run with `rulez debug`
+
+Test that the rule matches before going live:
+
+```bash
+# Should be BLOCKED
+$RULEZ_BIN debug pre --tool Bash --command "git push --force origin main"
+```
+
+Expected output (look for):
+```
+Summary:
+----------------------------------------
+✗ Blocked: ...
+```
+
+```bash
+# Should be ALLOWED
+$RULEZ_BIN debug pre --tool Bash --command "echo hello"
+```
+
+Expected output:
+```
+Summary:
+----------------------------------------
+✓ Allowed (no matching rules)
+```
+
+```bash
+# Also test the -f variant
+$RULEZ_BIN debug pre --tool Bash --command "git push -f origin main"
+```
+
+Expected: Blocked.
+
+### Step 5: Live test with Claude Code
+
+```bash
+cd /tmp/rulez-test-block
+claude -p "Run this exact command: git push --force origin main" --allowedTools Bash --max-turns 2
+```
+
+**What to observe**:
+- Claude should receive a block response from RuleZ
+- Claude may report that the operation was blocked, or it may refuse on its own (both are acceptable)
+
+### Step 6: Verify logs
+
+```bash
+# Check the RuleZ log for the block event
+cat ~/.claude/logs/rulez.log | tail -5
+```
+
+Look for:
+- `"block-force-push"` rule name in the log
+- `"Block"` outcome
+
+### Step 7: Cleanup
+
+```bash
+rm -rf /tmp/rulez-test-block
+```
+
+### Pass/Fail Criteria
+
+| Check | Expected |
+|-------|----------|
+| `rulez debug pre --tool Bash --command "git push --force origin main"` | Blocked |
+| `rulez debug pre --tool Bash --command "echo hello"` | Allowed |
+| Log contains `block-force-push` after live test | Yes |
+| Claude does not successfully run force push | Yes |
+
+---
+
+## Use Case 2: Context Injection
+
+**Goal**: Verify that RuleZ injects context when Claude reads or edits files matching a pattern.
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-test-inject/.claude/context
+cd /tmp/rulez-test-inject
+```
+
+### Step 2: Create sample files
+
+```bash
+# A context file that should be injected
+cat > .claude/context/security-guidelines.md << 'EOF'
+# Security Guidelines
+
+- Never store secrets in source code
+- Always use environment variables for API keys
+- Validate all user input before processing
+- Use parameterized queries for database access
+EOF
+
+# A sample source file to trigger the rule
+cat > app.py << 'EOF'
+import os
+
+def get_api_key():
+    return os.environ.get("API_KEY", "")
+
+def process_input(user_data):
+    # TODO: add validation
+    return user_data
+EOF
+```
+
+### Step 3: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: inject-security-context
+    description: "Inject security guidelines when editing Python files"
+    matchers:
+      tools: ["Write", "Edit", "Read"]
+      extensions: [".py"]
+    actions:
+      inject: ".claude/context/security-guidelines.md"
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+EOF
+```
+
+### Step 4: Install RuleZ
+
+```bash
+$RULEZ_BIN install
+```
+
+### Step 5: Dry-run with `rulez debug`
+
+```bash
+# Should inject context (Read tool on a .py file)
+$RULEZ_BIN debug pre --tool Read --path "app.py"
+```
+
+Expected output (look for):
+```
+Summary:
+----------------------------------------
+✓ Allowed with injected context (XXX chars)
+```
+
+```bash
+# Should NOT inject (non-.py file)
+$RULEZ_BIN debug pre --tool Read --path "README.md"
+```
+
+Expected:
+```
+✓ Allowed (no matching rules)
+```
+
+```bash
+# JSON mode for detailed inspection
+$RULEZ_BIN debug pre --tool Read --path "app.py" --json
+```
+
+Look for `"outcome": "Allow"` and `matchedRules` containing `"inject-security-context"`.
+
+### Step 6: Live test with Claude Code
+
+```bash
+cd /tmp/rulez-test-inject
+claude -p "Read app.py and suggest improvements" --allowedTools Read --max-turns 3
+```
+
+**What to observe**:
+- Claude's response should reflect awareness of the security guidelines
+- The injected context influences Claude to mention input validation, environment variables, etc.
+
+### Step 7: Verify logs
+
+```bash
+cat ~/.claude/logs/rulez.log | tail -5
+```
+
+Look for:
+- `"inject-security-context"` rule name
+- Evidence of context injection (injected file path in the log)
+
+### Step 8: Cleanup
+
+```bash
+rm -rf /tmp/rulez-test-inject
+```
+
+### Pass/Fail Criteria
+
+| Check | Expected |
+|-------|----------|
+| `rulez debug pre --tool Read --path "app.py"` | Allowed with injected context |
+| `rulez debug pre --tool Read --path "README.md"` | Allowed (no matching rules) |
+| Log contains `inject-security-context` after live test | Yes |
+| Claude's response mentions security practices | Yes (soft check) |
+
+---
+
+## Use Case 3: Debug Dry-Run
+
+**Goal**: Verify the `rulez debug` command can simulate all event types and produce useful diagnostic output.
+
+This use case does not require Claude Code -- it tests the debug tooling itself.
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-test-debug/.claude
+cd /tmp/rulez-test-debug
+```
+
+### Step 2: Write hooks.yaml with multiple rules
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: block-rm-rf
+    description: "Block recursive deletion commands"
+    matchers:
+      tools: ["Bash"]
+      command_match: "rm\\s+-rf\\s+/"
+    actions:
+      block: true
+
+  - name: inject-on-edit
+    description: "Inject coding standards when editing files"
+    matchers:
+      tools: ["Edit", "Write"]
+    actions:
+      inject_inline: "Follow the project coding standards: use 4-space indentation, add docstrings to all public functions."
+
+  - name: prompt-guard
+    description: "Warn on prompts mentioning credentials"
+    matchers:
+      prompt_match:
+        pattern: "password|secret|credential|api.key"
+    actions:
+      inject_inline: "SECURITY NOTICE: Be careful with credential-related operations. Never output secrets in plain text."
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+EOF
+```
+
+### Step 3: Test each event type
+
+**PreToolUse - Block test**:
+```bash
+$RULEZ_BIN debug pre --tool Bash --command "rm -rf /important-data"
+```
+Expected: `Blocked`
+
+**PreToolUse - Allow test**:
+```bash
+$RULEZ_BIN debug pre --tool Bash --command "ls -la"
+```
+Expected: `Allowed (no matching rules)`
+
+**PreToolUse - Inject test**:
+```bash
+$RULEZ_BIN debug pre --tool Edit --path "main.py"
+```
+Expected: `Allowed with injected context`
+
+**UserPromptSubmit - Prompt guard test**:
+```bash
+$RULEZ_BIN debug prompt --prompt "Show me the database password"
+```
+Expected: `Allowed with injected context` (the security notice)
+
+**UserPromptSubmit - Clean prompt**:
+```bash
+$RULEZ_BIN debug prompt --prompt "List all files in the project"
+```
+Expected: `Allowed (no matching rules)`
+
+**SessionStart**:
+```bash
+$RULEZ_BIN debug session
+```
+Expected: Runs without error, shows `Allowed`
+
+**PostToolUse**:
+```bash
+$RULEZ_BIN debug post --tool Bash --command "echo hello"
+```
+Expected: Runs without error
+
+### Step 4: Test JSON output mode
+
+```bash
+$RULEZ_BIN debug pre --tool Bash --command "rm -rf /data" --json
+```
+
+Verify the JSON output has this structure:
+```json
+{
+  "outcome": "Block",
+  "reason": "...",
+  "matchedRules": ["block-rm-rf"],
+  "evaluationTimeMs": ...,
+  "evaluations": [
+    {
+      "ruleName": "block-rm-rf",
+      "matched": true,
+      "timeMs": ...
+    }
+  ]
+}
+```
+
+### Step 5: Test verbose mode
+
+```bash
+$RULEZ_BIN debug pre --tool Edit --path "main.py" --verbose
+```
+
+Look for additional output showing all rule names and their configurations.
+
+### Step 6: Cleanup
+
+```bash
+rm -rf /tmp/rulez-test-debug
+```
+
+### Pass/Fail Criteria
+
+| Check | Expected |
+|-------|----------|
+| `debug pre` with blocking command | Blocked |
+| `debug pre` with safe command | Allowed |
+| `debug pre` with Edit tool | Allowed with injected context |
+| `debug prompt` with credential mention | Allowed with injected context |
+| `debug prompt` with clean prompt | Allowed (no matching rules) |
+| `debug session` | Completes without error |
+| `debug post` | Completes without error |
+| `--json` flag produces valid JSON | Yes |
+| `--verbose` flag shows extra detail | Yes |
+
+---
+
+## Troubleshooting
+
+### `rulez install` says "already installed"
+
+```bash
+$RULEZ_BIN uninstall
+$RULEZ_BIN install
+```
+
+### No log entries appear
+
+1. Check that `debug_logs: true` is set in hooks.yaml
+2. Verify the log path: `ls -la ~/.claude/logs/rulez.log`
+3. Run `$RULEZ_BIN validate` to check configuration
+
+### `rulez debug` says "No configuration found"
+
+Make sure you are in the test project directory that contains `.claude/hooks.yaml`:
+
+```bash
+cd /tmp/rulez-test-block
+$RULEZ_BIN debug pre --tool Bash --command "test"
+```
+
+### Claude refuses the command on its own (before RuleZ)
+
+This is expected for dangerous commands. Claude has its own safety checks. The key verification is that `rulez debug` shows `Blocked` -- this confirms RuleZ would have blocked it regardless of Claude's decision.

--- a/runbooks/02-opencode.md
+++ b/runbooks/02-opencode.md
@@ -1,0 +1,243 @@
+# Runbook 02: OpenCode Manual Testing
+
+Manual testing of RuleZ with OpenCode CLI.
+
+## Prerequisites
+
+- [ ] OpenCode CLI installed (`opencode --version`)
+- [ ] RuleZ binary built (`cargo build --release` from repo root)
+- [ ] Know your RuleZ binary path
+
+```bash
+export RULEZ_BIN="/path/to/agent_rulez/target/release/rulez"
+```
+
+## Platform Notes
+
+OpenCode uses different event names than Claude Code:
+
+| OpenCode Event | Claude Code Equivalent |
+|---------------|----------------------|
+| `tool.execute.before` | `PreToolUse` |
+| `tool.execute.after` | `PostToolUse` |
+| `file.edited` | (file change hook) |
+| `session.updated` | `SessionStart` |
+
+RuleZ maps these automatically via the `rulez opencode hook` adapter command.
+
+The OpenCode settings file is at `.opencode/settings.json` (project) or `~/.opencode/settings.json` (user).
+
+---
+
+## Use Case 1: Block Force Push
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-opencode-test/.claude
+cd /tmp/rulez-opencode-test
+git init
+```
+
+Note: hooks.yaml is always in `.claude/hooks.yaml` regardless of the platform.
+
+### Step 2: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: block-force-push
+    description: "Prevents destructive force push operations"
+    matchers:
+      tools: ["Bash"]
+      command_match: "git push.*--force|git push.*-f"
+    actions:
+      block: true
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+  fail_open: false
+EOF
+```
+
+### Step 3: Install for OpenCode
+
+```bash
+$RULEZ_BIN opencode install
+```
+
+Expected output:
+```
+Installing OpenCode hooks...
+
+  Binary: /path/to/rulez
+  Config: .opencode/settings.json
+  Scope: project
+
+✓ OpenCode hooks installed successfully!
+
+Hook registered for events:
+  * file.edited
+  * tool.execute.before
+  * tool.execute.after
+  * session.updated
+```
+
+### Step 4: Verify with doctor
+
+```bash
+$RULEZ_BIN opencode doctor
+```
+
+This checks that the OpenCode settings.json is correctly configured.
+
+### Step 5: Dry-run with `rulez debug`
+
+The `rulez debug` command simulates Claude Code events, which is useful for verifying rule logic even when testing other platforms. The rule matching logic is identical across platforms.
+
+```bash
+# Should be BLOCKED
+$RULEZ_BIN debug pre --tool Bash --command "git push --force origin main"
+
+# Should be ALLOWED
+$RULEZ_BIN debug pre --tool Bash --command "echo hello"
+```
+
+### Step 6: Live test with OpenCode
+
+```bash
+cd /tmp/rulez-opencode-test
+opencode
+```
+
+In the OpenCode session, ask it to run `git push --force origin main`.
+
+**What to observe**:
+- RuleZ should intercept the `tool.execute.before` event
+- The operation should be blocked
+
+### Step 7: Verify logs
+
+```bash
+cat ~/.opencode/logs/rulez.log | tail -5
+```
+
+### Step 8: Cleanup
+
+```bash
+rm -rf /tmp/rulez-opencode-test
+```
+
+### Pass/Fail Criteria
+
+| Check | Expected |
+|-------|----------|
+| `rulez opencode install` succeeds | Yes |
+| `rulez opencode doctor` passes | Yes |
+| `rulez debug pre` with force push | Blocked |
+| Force push blocked in live OpenCode session | Yes |
+
+---
+
+## Use Case 2: Context Injection
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-opencode-inject/.claude/context
+cd /tmp/rulez-opencode-inject
+```
+
+### Step 2: Create sample files
+
+```bash
+cat > .claude/context/security-guidelines.md << 'EOF'
+# Security Guidelines
+
+- Never store secrets in source code
+- Always use environment variables for API keys
+- Validate all user input before processing
+EOF
+
+cat > app.py << 'EOF'
+import os
+
+def get_api_key():
+    return os.environ.get("API_KEY", "")
+EOF
+```
+
+### Step 3: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: inject-security-context
+    description: "Inject security guidelines when editing Python files"
+    matchers:
+      tools: ["Write", "Edit", "Read"]
+      extensions: [".py"]
+    actions:
+      inject: ".claude/context/security-guidelines.md"
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+EOF
+```
+
+### Step 4: Install and verify
+
+```bash
+$RULEZ_BIN opencode install
+$RULEZ_BIN opencode doctor
+```
+
+### Step 5: Dry-run
+
+```bash
+$RULEZ_BIN debug pre --tool Read --path "app.py"
+```
+
+Expected: `Allowed with injected context`
+
+### Step 6: Live test
+
+```bash
+cd /tmp/rulez-opencode-inject
+opencode
+```
+
+Ask OpenCode to read and improve `app.py`. The security context should influence its suggestions.
+
+### Step 7: Cleanup
+
+```bash
+rm -rf /tmp/rulez-opencode-inject
+```
+
+---
+
+## Use Case 3: Debug Dry-Run
+
+Same as [01-claude-code.md Use Case 3](01-claude-code.md#use-case-3-debug-dry-run). The `rulez debug` command is platform-independent. Follow the steps in that runbook.
+
+---
+
+## Troubleshooting
+
+### `rulez opencode doctor` reports issues
+
+- Check that `.opencode/settings.json` exists and contains the hook entries
+- Re-run `$RULEZ_BIN opencode install`
+
+### OpenCode doesn't trigger hooks
+
+- Verify OpenCode version supports the hooks API
+- Check `~/.opencode/logs/rulez.log` for any entries
+- Run `$RULEZ_BIN opencode doctor --json` for detailed diagnostics

--- a/runbooks/03-gemini-cli.md
+++ b/runbooks/03-gemini-cli.md
@@ -1,0 +1,264 @@
+# Runbook 03: Gemini CLI Manual Testing
+
+Manual testing of RuleZ with Gemini CLI.
+
+## Prerequisites
+
+- [ ] Gemini CLI installed (`gemini --version`)
+- [ ] RuleZ binary built (`cargo build --release` from repo root)
+- [ ] Know your RuleZ binary path
+
+```bash
+export RULEZ_BIN="/path/to/agent_rulez/target/release/rulez"
+```
+
+## Platform Notes
+
+Gemini CLI has the richest event model of all supported platforms (11 event types):
+
+| Gemini Event | Description |
+|-------------|-------------|
+| `BeforeTool` | Before a tool executes (similar to `PreToolUse`) |
+| `AfterTool` | After a tool executes (similar to `PostToolUse`) |
+| `BeforeAgent` | Before an agent turn |
+| `AfterAgent` | After an agent turn |
+| `BeforeModel` | Before a model call |
+| `AfterModel` | After a model call |
+| `BeforeToolSelection` | Before tool selection |
+| `SessionStart` | Session begins |
+| `SessionEnd` | Session ends |
+| `Notification` | General notifications |
+| `PreCompact` | Before context compaction |
+
+RuleZ maps these automatically via the `rulez gemini hook` adapter command.
+
+The Gemini settings file is at `.gemini/settings.json` (project), `~/.gemini/settings.json` (user), or system-level.
+
+---
+
+## Use Case 1: Block Force Push
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-gemini-test/.claude
+cd /tmp/rulez-gemini-test
+git init
+```
+
+Note: hooks.yaml is always in `.claude/hooks.yaml` regardless of the platform.
+
+### Step 2: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: block-force-push
+    description: "Prevents destructive force push operations"
+    matchers:
+      tools: ["Bash"]
+      command_match: "git push.*--force|git push.*-f"
+    actions:
+      block: true
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+  fail_open: false
+EOF
+```
+
+### Step 3: Install for Gemini
+
+```bash
+$RULEZ_BIN gemini install
+```
+
+Expected output:
+```
+Installing Gemini CLI hooks...
+
+  Binary: /path/to/rulez
+  Config: .gemini/settings.json
+  Scope: project
+
+✓ Gemini hooks installed successfully!
+
+Hook registered for events:
+  * BeforeTool
+  * AfterTool
+  * BeforeAgent
+  * AfterAgent
+  * BeforeModel
+  * AfterModel
+  * BeforeToolSelection
+  * SessionStart
+  * SessionEnd
+  * Notification
+  * PreCompact
+```
+
+### Step 4: Verify with doctor
+
+```bash
+$RULEZ_BIN gemini doctor
+```
+
+### Step 5: Dry-run with `rulez debug`
+
+```bash
+# Should be BLOCKED
+$RULEZ_BIN debug pre --tool Bash --command "git push --force origin main"
+
+# Should be ALLOWED
+$RULEZ_BIN debug pre --tool Bash --command "echo hello"
+```
+
+### Step 6: Live test with Gemini CLI
+
+```bash
+cd /tmp/rulez-gemini-test
+gemini
+```
+
+In the Gemini session, ask it to run `git push --force origin main`.
+
+**What to observe**:
+- RuleZ should intercept the `BeforeTool` event
+- The operation should be blocked
+
+### Step 7: Verify logs
+
+```bash
+cat ~/.gemini/logs/rulez.log | tail -5
+```
+
+### Step 8: Cleanup
+
+```bash
+rm -rf /tmp/rulez-gemini-test
+```
+
+### Pass/Fail Criteria
+
+| Check | Expected |
+|-------|----------|
+| `rulez gemini install` succeeds | Yes |
+| `rulez gemini doctor` passes | Yes |
+| `rulez debug pre` with force push | Blocked |
+| Force push blocked in live Gemini session | Yes |
+
+---
+
+## Use Case 2: Context Injection
+
+### Step 1: Create test project
+
+```bash
+mkdir -p /tmp/rulez-gemini-inject/.claude/context
+cd /tmp/rulez-gemini-inject
+```
+
+### Step 2: Create sample files
+
+```bash
+cat > .claude/context/security-guidelines.md << 'EOF'
+# Security Guidelines
+
+- Never store secrets in source code
+- Always use environment variables for API keys
+- Validate all user input before processing
+EOF
+
+cat > app.py << 'EOF'
+import os
+
+def get_api_key():
+    return os.environ.get("API_KEY", "")
+EOF
+```
+
+### Step 3: Write hooks.yaml
+
+```bash
+cat > .claude/hooks.yaml << 'EOF'
+version: "1.0"
+
+rules:
+  - name: inject-security-context
+    description: "Inject security guidelines when editing Python files"
+    matchers:
+      tools: ["Write", "Edit", "Read"]
+      extensions: [".py"]
+    actions:
+      inject: ".claude/context/security-guidelines.md"
+
+settings:
+  log_level: "debug"
+  debug_logs: true
+EOF
+```
+
+### Step 4: Install and verify
+
+```bash
+$RULEZ_BIN gemini install
+$RULEZ_BIN gemini doctor
+```
+
+### Step 5: Dry-run
+
+```bash
+$RULEZ_BIN debug pre --tool Read --path "app.py"
+```
+
+Expected: `Allowed with injected context`
+
+### Step 6: Live test
+
+```bash
+cd /tmp/rulez-gemini-inject
+gemini
+```
+
+Ask Gemini to read and improve `app.py`. The security context should influence its suggestions.
+
+### Step 7: Cleanup
+
+```bash
+rm -rf /tmp/rulez-gemini-inject
+```
+
+---
+
+## Use Case 3: Debug Dry-Run
+
+Same as [01-claude-code.md Use Case 3](01-claude-code.md#use-case-3-debug-dry-run). The `rulez debug` command is platform-independent. Follow the steps in that runbook.
+
+---
+
+## Troubleshooting
+
+### `rulez gemini doctor` reports issues
+
+- Check that `.gemini/settings.json` exists and contains the hook entries
+- Re-run `$RULEZ_BIN gemini install`
+
+### Gemini CLI doesn't trigger hooks
+
+- Verify your Gemini CLI version supports the hooks/extensions API
+- Check `~/.gemini/logs/rulez.log` for any entries
+- Run `$RULEZ_BIN gemini doctor --json` for detailed diagnostics
+
+### Gemini uses different tool names
+
+Gemini CLI may use different tool names than Claude Code. If rules don't match, check what tool names Gemini reports:
+
+```bash
+# Check logs for actual tool names
+cat ~/.gemini/logs/rulez.log | grep tool_name
+```
+
+Adjust your `matchers.tools` values accordingly.

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,132 @@
+# RuleZ Manual Testing Runbooks
+
+Hands-on runbooks for manually testing RuleZ across multiple AI coding tool platforms.
+
+## Overview
+
+These runbooks guide you through testing three core RuleZ capabilities:
+
+1. **Block Force Push** - Security rule that blocks dangerous git operations
+2. **Context Injection** - Automatically inject guidance when editing specific files
+3. **Debug Dry-Run** - Use `rulez debug` to simulate events before going live
+
+Each runbook targets a specific AI coding tool platform and walks through the same use cases so you can verify consistent behavior across tools.
+
+## Runbooks
+
+| Runbook | Platform | Status |
+|---------|----------|--------|
+| [01-claude-code.md](01-claude-code.md) | Claude Code | Ready |
+| [02-opencode.md](02-opencode.md) | OpenCode | Ready |
+| [03-gemini-cli.md](03-gemini-cli.md) | Gemini CLI | Ready |
+| 04-copilot-cli.md | GitHub Copilot CLI | Planned |
+
+## Prerequisites
+
+### Build RuleZ
+
+From the repository root:
+
+```bash
+cargo build --release
+```
+
+The binary will be at `target/release/rulez`.
+
+### Verify the binary works
+
+```bash
+./target/release/rulez --version
+./target/release/rulez --help
+```
+
+### Platform-specific requirements
+
+| Platform | Requirement | Install Check |
+|----------|-------------|---------------|
+| Claude Code | Claude Code CLI installed | `claude --version` |
+| OpenCode | OpenCode CLI installed | `opencode --version` |
+| Gemini CLI | Gemini CLI installed | `gemini --version` |
+
+### Test project directory
+
+All runbooks use a **separate temporary test project** (not this repository). Each runbook includes instructions to create a fresh test directory, which keeps your repo clean and lets you experiment freely.
+
+## Approach
+
+Each use case follows the same pattern:
+
+```
+Setup --> Configure hooks.yaml --> Install RuleZ --> Dry-Run with `rulez debug` --> Live Test --> Verify --> Cleanup
+```
+
+1. **Setup** - Create a temp project directory with sample files
+2. **Configure** - Write a `hooks.yaml` with rules for the use case
+3. **Install** - Run `rulez install` (or platform-specific `rulez <platform> install`)
+4. **Dry-Run** - Use `rulez debug` to simulate events and verify rules match
+5. **Live Test** - Run the actual AI coding tool and trigger the rule
+6. **Verify** - Check logs and tool behavior for expected outcomes
+7. **Cleanup** - Remove the temp project
+
+## hooks.yaml Schema Reference
+
+Quick reference for writing test rules.
+
+### Rule structure
+
+```yaml
+version: "1.0"
+
+rules:
+  - name: rule-name              # Unique identifier
+    description: "What it does"  # Human-readable
+    matchers:                    # When to trigger
+      tools: ["Bash", "Edit"]   # Tool names
+      command_match: "regex"     # Regex on command string
+      directories: ["src/**"]   # Glob patterns on file paths
+      extensions: [".rs"]       # File extension filter
+      operations: ["write"]     # Operation types
+      prompt_match:              # Match on user prompt text
+        pattern: "regex"
+      require_fields: ["field"]  # Required JSON fields in tool_input
+      field_types:               # Type checks on tool_input fields
+        field_name: "string"
+    actions:                     # What to do
+      block: true                # Block the operation
+      inject: "path/to/file.md" # Inject file contents as context
+      inject_inline: "markdown"  # Inject inline markdown
+      inject_command: "cmd"      # Run command, inject stdout
+      run:                       # Run a validator script
+        command: "script.sh"
+      block_if_match: "regex"    # Block only if regex matches
+      validate_expr: "expr"      # evalexpr boolean expression
+      inline_script: "script"    # Inline shell script validation
+
+settings:
+  log_level: "debug"             # info, debug, trace
+  debug_logs: true               # Enable detailed logging
+  fail_open: false               # Allow on error (default: false)
+```
+
+### Event types (Claude Code)
+
+| Event | When | Common Matchers |
+|-------|------|-----------------|
+| PreToolUse | Before tool runs | `tools`, `command_match`, `directories` |
+| PostToolUse | After tool runs | `tools` |
+| SessionStart | Session begins | (none needed) |
+| SessionEnd | Session ends | (none needed) |
+| PermissionRequest | Tool needs permission | `tools` |
+| UserPromptSubmit | User sends prompt | `prompt_match` |
+| PreCompact | Before context compaction | (none needed) |
+
+## Log file locations
+
+- **Claude Code**: `~/.claude/logs/rulez.log`
+- **OpenCode**: `~/.opencode/logs/rulez.log`
+- **Gemini CLI**: `~/.gemini/logs/rulez.log`
+
+## Related
+
+- [Integration Test Suite](../test/integration/README.md) - Automated integration tests
+- [RuleZ CLI Help](../rulez/README.md) - CLI reference

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,6 +1,6 @@
-# CCH Integration Test Suite
+# RuleZ Integration Test Suite
 
-End-to-end integration tests that verify CCH (Claude Context Hooks) works correctly when invoked by the real Claude CLI.
+End-to-end integration tests that verify RuleZ (AI Policy Engine) works correctly when invoked by the real Claude CLI.
 
 ## Prerequisites
 
@@ -9,9 +9,9 @@ End-to-end integration tests that verify CCH (Claude Context Hooks) works correc
    claude --version
    ```
 
-2. **CCH Binary** - Built automatically by the test runner
+2. **RuleZ Binary** - Built automatically by the test runner
    ```bash
-   cd cch_cli && cargo build --release
+   cd rulez && cargo build --release
    ```
 
 3. **Bash** - Tests use bash scripts
@@ -37,10 +37,10 @@ task itest  # alias
 
 | Test | Description | What It Verifies |
 |------|-------------|------------------|
-| `01-block-force-push` | Block dangerous git operations | CCH blocks `git push --force` |
-| `02-context-injection` | Inject context for file types | CCH injects CDK context for `.cdk.ts` files |
-| `03-session-logging` | Audit log creation | CCH creates JSON Lines logs with timing |
-| `04-permission-explanations` | Permission request context | CCH provides context during permission prompts |
+| `01-block-force-push` | Block dangerous git operations | RuleZ blocks `git push --force` |
+| `02-context-injection` | Inject context for file types | RuleZ injects CDK context for `.cdk.ts` files |
+| `03-session-logging` | Audit log creation | RuleZ creates JSON Lines logs with timing |
+| `04-permission-explanations` | Permission request context | RuleZ provides context during tool use |
 
 ## Directory Structure
 
@@ -73,9 +73,9 @@ test/integration/
 ## How Tests Work
 
 1. **Setup** - Create temp workspace, copy use-case files
-2. **Install** - Run `cch install` in the workspace
+2. **Install** - Run `rulez install` in the workspace
 3. **Execute** - Invoke Claude CLI with specific prompts
-4. **Verify** - Check CCH logs for expected behavior
+4. **Verify** - Check RuleZ logs for expected behavior
 5. **Cleanup** - Remove temp workspace
 
 ## Writing New Tests
@@ -111,7 +111,7 @@ test/integration/
    
    # Setup
    WORKSPACE=$(setup_workspace "$SCRIPT_DIR")
-   install_cch "$WORKSPACE"
+   install_rulez "$WORKSPACE"
    
    # Test
    run_claude "$WORKSPACE" "Your prompt" "Bash" 3
@@ -134,7 +134,7 @@ test/integration/
 ### Setup/Teardown
 - `start_test "name"` - Begin a test
 - `setup_workspace "/path"` - Create temp workspace
-- `install_cch [workspace]` - Install CCH in workspace
+- `install_rulez [workspace]` - Install RuleZ in workspace
 - `cleanup_workspace` - Remove temp workspace
 - `end_test` - Report results
 
@@ -143,7 +143,7 @@ test/integration/
 - `CLAUDE_STDOUT` / `CLAUDE_STDERR` - Captured output
 
 ### Logging
-- `clear_cch_logs` - Clear log file
+- `clear_rulez_logs` - Clear log file
 - `get_log_line_count` - Current log size
 - `log_contains "pattern"` - Check if log has pattern
 - `log_contains_since <line> "pattern"` - Check recent entries
@@ -172,8 +172,8 @@ export PATH="$PATH:/path/to/claude"
 - Use `--max-turns` to limit iterations
 
 ### No log entries
-- Verify CCH is installed: `cch validate`
-- Check log path: `~/.claude/logs/cch.log`
+- Verify RuleZ is installed: `rulez validate`
+- Check log path: `~/.claude/logs/rulez.log`
 - Enable debug: Set `debug_logs: true` in hooks.yaml
 
 ### Permission denied
@@ -213,6 +213,5 @@ Test results are saved to `results/` as JSON files:
 
 ## Related Documentation
 
-- [CCH README](../../cch_cli/README.md) - CCH binary documentation
-- [Hooks Configuration](../../cch_cli/docs/hooks-config.md) - hooks.yaml reference
+- [RuleZ README](../../rulez/README.md) - RuleZ binary documentation
 - [Using Claude Code CLI Skill](../../.opencode/skill/using-claude-code-cli/SKILL.md) - CLI automation patterns

--- a/test/integration/run-all.sh
+++ b/test/integration/run-all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run all CCH integration tests
+# Run all RuleZ integration tests
 #
 # Usage:
 #   ./run-all.sh              # Run all tests (soft assertions)
@@ -48,7 +48,7 @@ done
 # Banner
 echo ""
 echo -e "${BLUE}+============================================================+${NC}"
-echo -e "${BLUE}|       CCH Integration Test Suite                           |${NC}"
+echo -e "${BLUE}|       RuleZ Integration Test Suite                         |${NC}"
 echo -e "${BLUE}+============================================================+${NC}"
 if [ "${STRICT_MODE:-0}" = "1" ]; then
     echo -e "${YELLOW}|       MODE: STRICT (fail-fast on first assertion failure) |${NC}"

--- a/test/integration/use-cases/01-block-force-push/.claude/hooks.yaml
+++ b/test/integration/use-cases/01-block-force-push/.claude/hooks.yaml
@@ -1,4 +1,4 @@
-# CCH Integration Test - Block Force Push
+# RuleZ Integration Test - Block Force Push
 # This configuration blocks dangerous git operations like force push and hard reset.
 
 version: "1.0"

--- a/test/integration/use-cases/01-block-force-push/test.sh
+++ b/test/integration/use-cases/01-block-force-push/test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Integration Test - Block Force Push
 #
-# Verifies that CCH blocks dangerous git operations when Claude attempts them.
+# Verifies that RuleZ blocks dangerous git operations when Claude attempts them.
 #
 # Test Flow:
 #   1. Setup workspace with block-force-push hooks.yaml
-#   2. Install CCH in the workspace
+#   2. Install RuleZ in the workspace
 #   3. Run Claude with a prompt that should trigger force push
-#   4. Verify CCH blocked the operation
+#   4. Verify RuleZ blocked the operation
 #   5. Verify logs contain the block event
 
 set -euo pipefail
@@ -24,7 +24,7 @@ check_prerequisites
 # Setup
 section "Setup"
 WORKSPACE=$(setup_workspace "$SCRIPT_DIR")
-install_cch "$WORKSPACE"
+install_rulez "$WORKSPACE"
 
 # Record log position before test
 LOG_LINE_BEFORE=$(get_log_line_count)
@@ -35,12 +35,12 @@ section "Test 1 - Force Push Blocked"
 
 # Create a prompt that asks Claude to run git push --force
 # Note - Claude may not actually execute if it recognizes the danger, 
-# but CCH should intercept the PreToolUse event
+# but RuleZ should intercept the PreToolUse event
 PROMPT="Please run this exact command - git push --force origin main. Do not ask questions, just run it."
 
 run_claude "$WORKSPACE" "$PROMPT" "Bash" 2 || true
 
-# Check if CCH logged a block event
+# Check if RuleZ logged a block event
 section "Verification"
 
 # Give logs a moment to flush
@@ -48,24 +48,24 @@ sleep 1
 
 # Check for block event in logs
 assert_log_contains_since "$LOG_LINE_BEFORE" "block-force-push" \
-    "CCH log should contain block-force-push rule match"
+    "RuleZ log should contain block-force-push rule match"
 
 assert_log_contains_since "$LOG_LINE_BEFORE" '"outcome"' \
-    "CCH log should contain outcome field"
+    "RuleZ log should contain outcome field"
 
 # Additional check - look for Block outcome
 if log_contains_since "$LOG_LINE_BEFORE" '"Block"'; then
     ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
-    echo -e "  ${GREEN}+${NC} PASS - CCH blocked the operation"
+    echo -e "  ${GREEN}+${NC} PASS - RuleZ blocked the operation"
 else
-    # It's possible Claude refused to run the command before CCH saw it
+    # It's possible Claude refused to run the command before RuleZ saw it
     # Check if there's any log entry at all
     NEW_ENTRIES=$(get_new_log_entries "$LOG_LINE_BEFORE" | wc -l | tr -d ' ')
     if [ "$NEW_ENTRIES" -gt 0 ]; then
-        echo -e "  ${YELLOW}!${NC} INFO - CCH processed event but may not have blocked (Claude may have refused)"
+        echo -e "  ${YELLOW}!${NC} INFO - RuleZ processed event but may not have blocked (Claude may have refused)"
         ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
     else
-        echo -e "  ${YELLOW}!${NC} INFO - No new CCH log entries (Claude may have refused without tool call)"
+        echo -e "  ${YELLOW}!${NC} INFO - No new RuleZ log entries (Claude may have refused without tool call)"
         ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
     fi
 fi
@@ -90,9 +90,9 @@ else
     NEW_ENTRIES=$(get_new_log_entries "$LOG_LINE_BEFORE_SAFE" | wc -l | tr -d ' ')
     if [ "$NEW_ENTRIES" -gt 0 ]; then
         ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
-        echo -e "  ${GREEN}+${NC} PASS - CCH processed safe command"
+        echo -e "  ${GREEN}+${NC} PASS - RuleZ processed safe command"
     else
-        echo -e "  ${YELLOW}!${NC} INFO - No CCH log for safe command"
+        echo -e "  ${YELLOW}!${NC} INFO - No RuleZ log for safe command"
         ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
     fi
 fi

--- a/test/integration/use-cases/02-context-injection/.claude/hooks.yaml
+++ b/test/integration/use-cases/02-context-injection/.claude/hooks.yaml
@@ -1,4 +1,4 @@
-# CCH Integration Test - Context Injection
+# RuleZ Integration Test - Context Injection
 # This configuration injects context files when editing specific file types.
 
 version: "1.0"
@@ -8,19 +8,17 @@ rules:
     description: "Inject CDK best practices when editing CDK files"
     matchers:
       tools: ["Write", "Edit", "Read"]
-      path_match: ".*\\.cdk\\.ts$"
+      directories: ["**/*.cdk.ts"]
     actions:
-      inject_context:
-        - ".claude/context/cdk-best-practices.md"
+      inject: ".claude/context/cdk-best-practices.md"
 
   - name: terraform-context-injection
     description: "Inject Terraform guidelines when editing TF files"
     matchers:
       tools: ["Write", "Edit", "Read"]
-      path_match: ".*\\.tf$"
+      directories: ["**/*.tf"]
     actions:
-      inject_context:
-        - ".claude/context/terraform-guidelines.md"
+      inject: ".claude/context/terraform-guidelines.md"
 
 settings:
   log_level: "debug"

--- a/test/integration/use-cases/02-context-injection/test.sh
+++ b/test/integration/use-cases/02-context-injection/test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Integration Test - Context Injection
 #
-# Verifies that CCH injects context files when Claude operates on specific file types.
+# Verifies that RuleZ injects context files when Claude operates on specific file types.
 #
 # Test Flow:
 #   1. Setup workspace with context injection hooks.yaml
-#   2. Install CCH in the workspace
+#   2. Install RuleZ in the workspace
 #   3. Run Claude with a prompt to read/edit a .cdk.ts file
-#   4. Verify CCH injected the CDK context file
+#   4. Verify RuleZ injected the CDK context file
 #   5. Verify logs show the injection
 
 set -euo pipefail
@@ -24,7 +24,7 @@ check_prerequisites
 # Setup
 section "Setup"
 WORKSPACE=$(setup_workspace "$SCRIPT_DIR")
-install_cch "$WORKSPACE"
+install_rulez "$WORKSPACE"
 
 # Record log position before test
 LOG_LINE_BEFORE=$(get_log_line_count)
@@ -46,7 +46,7 @@ section "Verification"
 
 # Check for context injection in logs
 assert_log_contains_since "$LOG_LINE_BEFORE" "cdk-context-injection" \
-    "CCH log should contain cdk-context-injection rule match"
+    "RuleZ log should contain cdk-context-injection rule match"
 
 # Check for injected_files in the log
 if log_contains_since "$LOG_LINE_BEFORE" "injected_files"; then
@@ -59,11 +59,11 @@ else
     # Check if there's any matching log entry
     NEW_ENTRIES=$(get_new_log_entries "$LOG_LINE_BEFORE" | wc -l | tr -d ' ')
     if [ "$NEW_ENTRIES" -gt 0 ]; then
-        echo -e "  ${YELLOW}!${NC} INFO - CCH processed event (injection may be in response)"
+        echo -e "  ${YELLOW}!${NC} INFO - RuleZ processed event (injection may be in response)"
         ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
     else
         ASSERTIONS_FAILED=$((ASSERTIONS_FAILED + 1))
-        echo -e "  ${RED}x${NC} FAIL - No CCH log entries for context injection"
+        echo -e "  ${RED}x${NC} FAIL - No RuleZ log entries for context injection"
     fi
 fi
 

--- a/test/integration/use-cases/03-session-logging/.claude/hooks.yaml
+++ b/test/integration/use-cases/03-session-logging/.claude/hooks.yaml
@@ -1,5 +1,6 @@
-# CCH Integration Test - Session Logging
+# RuleZ Integration Test - Session Logging
 # This configuration enables comprehensive logging for audit trails.
+# Rules match all tool operations so they appear in the RuleZ log file.
 
 version: "1.0"
 
@@ -9,14 +10,14 @@ rules:
     matchers:
       tools: ["Bash"]
     actions:
-      log_level: "debug"
+      inject_inline: "<!-- audit: bash command logged -->"
 
   - name: log-file-operations
     description: "Log all file operations"
     matchers:
       tools: ["Write", "Edit", "Read"]
     actions:
-      log_level: "debug"
+      inject_inline: "<!-- audit: file operation logged -->"
 
 settings:
   log_level: "debug"

--- a/test/integration/use-cases/03-session-logging/test.sh
+++ b/test/integration/use-cases/03-session-logging/test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Integration Test - Session Logging
 #
-# Verifies that CCH creates proper audit logs with timing information.
+# Verifies that RuleZ creates proper audit logs with timing information.
 #
 # Test Flow:
 #   1. Setup workspace with logging-enabled hooks.yaml
-#   2. Install CCH in the workspace
+#   2. Install RuleZ in the workspace
 #   3. Clear existing logs
 #   4. Run Claude with a simple command
 #   5. Verify logs were created with proper structure
@@ -24,19 +24,19 @@ check_prerequisites
 # Setup
 section "Setup"
 WORKSPACE=$(setup_workspace "$SCRIPT_DIR")
-install_cch "$WORKSPACE"
+install_rulez "$WORKSPACE"
 
 # Clear logs before test
-clear_cch_logs
+clear_rulez_logs
 
 # Record initial state
 LOG_LINE_BEFORE=0
-echo -e "  ${GREEN}+${NC} Cleared CCH logs, starting fresh"
+echo -e "  ${GREEN}+${NC} Cleared RuleZ logs, starting fresh"
 
 # Test 1 - Run a command and verify logging
 section "Test 1 - Basic Logging"
 
-PROMPT="Run the command: echo 'CCH logging test' and show me the output."
+PROMPT="Run the command: echo 'RuleZ logging test' and show me the output."
 
 run_claude "$WORKSPACE" "$PROMPT" "Bash" 3 || true
 
@@ -47,7 +47,7 @@ sleep 2
 section "Verification - Log Structure"
 
 # Check that log file exists and has content
-assert_file_exists "$CCH_LOG" "CCH log file should exist"
+assert_file_exists "$RULEZ_LOG" "RuleZ log file should exist"
 
 # Count new log entries
 NEW_ENTRIES=$(get_new_log_entries "$LOG_LINE_BEFORE" | wc -l | tr -d ' ')

--- a/test/integration/use-cases/04-permission-explanations/.claude/hooks.yaml
+++ b/test/integration/use-cases/04-permission-explanations/.claude/hooks.yaml
@@ -1,26 +1,23 @@
-# CCH Integration Test - Permission Explanations
-# This configuration provides context during permission requests.
+# RuleZ Integration Test - Permission Explanations
+# This configuration provides context during tool use events.
+# Injects permission-related context when Bash or Write tools are used.
 
 version: "1.0"
 
 rules:
   - name: explain-bash-permissions
-    description: "Provide context when Bash permission is requested"
-    event_types: ["PermissionRequest"]
+    description: "Provide context when Bash tool is used"
     matchers:
       tools: ["Bash"]
     actions:
-      inject_context:
-        - ".claude/context/bash-permission-context.md"
+      inject: ".claude/context/bash-permission-context.md"
 
   - name: explain-write-permissions
-    description: "Provide context when Write permission is requested"
-    event_types: ["PermissionRequest"]
+    description: "Provide context when Write/Edit tools are used"
     matchers:
       tools: ["Write", "Edit"]
     actions:
-      inject_context:
-        - ".claude/context/write-permission-context.md"
+      inject: ".claude/context/write-permission-context.md"
 
 settings:
   log_level: "debug"

--- a/test/integration/use-cases/04-permission-explanations/test.sh
+++ b/test/integration/use-cases/04-permission-explanations/test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Integration Test - Permission Explanations
 #
-# Verifies that CCH provides context during permission request events.
+# Verifies that RuleZ provides context during permission request events.
 #
 # Test Flow:
 #   1. Setup workspace with permission explanation hooks.yaml
-#   2. Install CCH in the workspace
+#   2. Install RuleZ in the workspace
 #   3. Run Claude WITHOUT pre-approving tools (to trigger permission request)
-#   4. Verify CCH processed PermissionRequest event
+#   4. Verify RuleZ processed PermissionRequest event
 #   5. Verify logs show context injection for permission events
 
 set -euo pipefail
@@ -24,7 +24,7 @@ check_prerequisites
 # Setup
 section "Setup"
 WORKSPACE=$(setup_workspace "$SCRIPT_DIR")
-install_cch "$WORKSPACE"
+install_rulez "$WORKSPACE"
 
 # Record log position before test
 LOG_LINE_BEFORE=$(get_log_line_count)
@@ -50,7 +50,7 @@ sleep 2
 # Verification
 section "Verification"
 
-# Check for any CCH log entries
+# Check for any RuleZ log entries
 NEW_ENTRIES=$(get_new_log_entries "$LOG_LINE_BEFORE" | wc -l | tr -d ' ')
 echo -e "  ${BLUE}*${NC} Found $NEW_ENTRIES new log entries"
 


### PR DESCRIPTION
## Summary

- Add `runbooks/` directory with step-by-step manual testing runbooks for RuleZ across 3 AI coding tool platforms (Claude Code, OpenCode, Gemini CLI)
- Fix `test/integration/` scripts broken by the cch-to-rulez rename: update binary paths, function names, and variable names
- Fix broken `hooks.yaml` schemas in integration test use cases that used nonexistent fields (`path_match`, `inject_context`, `event_types`, `log_level` as action)

## Runbooks

Each runbook covers 3 core use cases using a separate temp test project:

1. **Block Force Push** — security rule blocking `git push --force`
2. **Context Injection** — inject guidance when editing specific file types
3. **Debug Dry-Run** — simulate events with `rulez debug` before going live

| Runbook | Platform |
|---------|----------|
| `runbooks/01-claude-code.md` | Claude Code |
| `runbooks/02-opencode.md` | OpenCode |
| `runbooks/03-gemini-cli.md` | Gemini CLI |
| `runbooks/README.md` | Overview, prerequisites, schema reference |

## Integration Test Fixes

| File | Fix |
|------|-----|
| `test-helpers.sh` | `CCH_CLI_DIR`/`CCH_BINARY`/`CCH_LOG` → `RULEZ_CLI_DIR`/`RULEZ_BINARY`/`RULEZ_LOG`; renamed all functions |
| `01-block-force-push/hooks.yaml` | Comment update only (schema was valid) |
| `02-context-injection/hooks.yaml` | `path_match` → `directories`, `inject_context` → `inject` |
| `03-session-logging/hooks.yaml` | Removed invalid `log_level` action, replaced with `inject_inline` |
| `04-permission-explanations/hooks.yaml` | Removed `event_types`, replaced `inject_context` with `inject` |
| All 4 `test.sh` files | Updated to use `install_rulez`, `clear_rulez_logs`, etc. |
| `run-all.sh`, `README.md` | Updated banner and documentation references |

## Testing

- `cargo fmt --all --check` — pass
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — pass
- `cargo test --tests --all-features --workspace` — all tests pass
- `cargo llvm-cov --all-features --workspace --no-report` — all tests pass